### PR TITLE
Node Support for v16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "email": "takiyotakahashi@gmail.com"
   },
   "engines": {
-    "node": "^16.5.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -37,17 +37,17 @@
   "license": "ISC",
   "devDependencies": {
     "@types/events": "^3.0.0",
-    "@types/node": "^17.0.42",
+    "@types/node": "^18.11.9",
     "@types/ws": "^8.5.3",
-    "discord.js": "^13.8.0",
-    "prettier": "^2.6.2",
+    "discord.js": "^14.6.0",
+    "prettier": "^2.7.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
-    "typedoc": "^0.22.18",
-    "typescript": "^4.7.3"
+    "typedoc": "^0.23.20",
+    "typescript": "^4.8.4"
   },
   "dependencies": {
     "events": "^3.3.0",
-    "shoukaku": "^3.1.0"
+    "shoukaku": "^3.2.2"
   }
 }


### PR DESCRIPTION
I am using the latest stable node version `18.12.1` and when I try to install the module it gives me error which states that ` kazagumo@2.2.3: The engine "node" is incompatible with this module. Expected version "^16.5.0". Got "18.12.1"`