### PR TITLE
chore: bump shoukaku version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "shoukaku": "^4.2.0"
+    "shoukaku": "^4.3.0"
   }
 }


### PR DESCRIPTION
Shokaku 4.3.0 supports DAVE, versions before do not, which lead to 400 errors.